### PR TITLE
Fixed fatal error in PHP < 5.4

### DIFF
--- a/includes/class-creativecommons-image.php
+++ b/includes/class-creativecommons-image.php
@@ -295,8 +295,7 @@ class CreativeCommonsImage {
 
     function save_image_license_metadata($post, $attachment) 
     {
-        foreach (['license_url', 'attribution_url', 'source_work_url',
-                  'extra_permissions_url'] as $field) {
+        foreach ( array( 'license_url', 'attribution_url', 'source_work_url', 'extra_permissions_url' ) as $field) {
             if (isset($attachment[$field])) {
                 update_post_meta(
                     $post['ID'],
@@ -305,7 +304,7 @@ class CreativeCommonsImage {
                 );
             }
         }
-        foreach (['attribution_name'] as $field) {
+        foreach ( array( 'attribution_name' ) as $field) {
             if (isset($attachment[$field])) {
                 update_post_meta(
                     $post['ID'],


### PR DESCRIPTION
This fixes the fatal error reported in issue #46. The problem was due to the syntax used for defining an array in function `save_image_license_metadata()`, where we did

`foreach ( ['license_url', 'attribution_url', 'source_work_url', 'extra_permissions_url'] as $field) {`

However, this compact syntax is only supported by PHP > 5.4. [Officially, WordPress supports](https://wordpress.org/about/requirements/) up to PHP 5.2, and since there is an [equivalent syntax](https://stackoverflow.com/questions/17772534/php-difference-between-array-and) that works just the same, I updated the files to use the backwards-compatible one :)

`foreach ( array( 'license_url', 'attribution_url', 'source_work_url', 'extra_permissions_url' ) as $field) {`

No change in function whatsoever, tested in my local setup by updating the license details of a media item and checking that they did indeed get through.